### PR TITLE
refactor comunication + spread and ack eofs

### DIFF
--- a/client/client.py
+++ b/client/client.py
@@ -1,7 +1,6 @@
 import socket
 import logging
 import csv
-import json
 
 from util import protocol
 
@@ -24,8 +23,7 @@ class Client:
         with open(flights_file, mode='r') as csv_file:
             csv_reader = csv.DictReader(csv_file)
             for row in csv_reader:
-                flight_register = json.dumps(row)
-                msg = protocol.encode_flight_register(flight_register)
+                msg = protocol.encode_flight_register(row)
                 try:
                     self.__send_msg(msg)
                     logging.debug(
@@ -35,7 +33,7 @@ class Client:
                         f'action: sent line | result: fail | error: {e}')
 
     def __send_eof(self):
-        msg = protocol.encode_eof()
+        msg = protocol.encode_eof_b()
         self.__send_msg(msg)
 
     def __start_connection_with_server(self):

--- a/filter_by_three_stopovers/filter_by_three_stopovers.py
+++ b/filter_by_three_stopovers/filter_by_three_stopovers.py
@@ -1,8 +1,10 @@
 import json
-from util.queue_methods import (send_message_to,acknowledge)
+from util.queue_methods import (send_message_to, acknowledge)
+
 
 class FilterByThreeStopovers:
-    def __init__(self, stopovers_column_name, columns_to_filter, max_stopovers, output_queue, query_number):
+    def __init__(self, stopovers_column_name, columns_to_filter, max_stopovers,
+                 output_queue, query_number):
         self.__max_stopovers = max_stopovers
         self.__stopovers_column_name = stopovers_column_name
         self.__columns_to_filter = columns_to_filter
@@ -10,25 +12,29 @@ class FilterByThreeStopovers:
         self.__query_number = query_number
 
     def callback(self, channel, method, properties, body):
-        if body.startswith(b'00'):
-            pass
-        # EOF
         flight = json.loads(body)
+        op_code = flight.get("op_code")
+        if op_code == 0:
+            # EOF
+            print("EOF !!!")
+            send_message_to(channel, self.__output_queue, body)
+            acknowledge(channel, method)
+            return
         stopovers = flight[self.__stopovers_column_name].split("||")[:-1]
-        if len(stopovers) >= self.__max_stopovers :
+        if len(stopovers) >= self.__max_stopovers:
             # Publish on query 3's queue here
-            message=self.__create_message(flight, stopovers, self.__query_number)
+            message = self.__create_message(
+                flight, stopovers, self.__query_number)
             send_message_to(channel, self.__output_queue, json.dumps(message))
             acknowledge(channel, method)
 
-
-    def __create_message(self,  flight, stopovers, query_number ):
+    def __create_message(self, flight, stopovers, query_number):
         message = dict()
         for i in range(len(self.__columns_to_filter)):
-            message[self.__columns_to_filter[i]] = flight[self.__columns_to_filter[i]]
-        
+            message[self.__columns_to_filter[i]
+                    ] = flight[self.__columns_to_filter[i]]
+
         message["stopovers"] = stopovers
         message["queryNumber"] = query_number
 
         return message
-

--- a/filter_by_three_stopovers/filter_by_three_stopovers.py
+++ b/filter_by_three_stopovers/filter_by_three_stopovers.py
@@ -16,7 +16,6 @@ class FilterByThreeStopovers:
         op_code = flight.get("op_code")
         if op_code == 0:
             # EOF
-            print("EOF !!!")
             send_message_to(channel, self.__output_queue, body)
             acknowledge(channel, method)
             return

--- a/initial_column_cleaner/initial_column_cleaner.py
+++ b/initial_column_cleaner/initial_column_cleaner.py
@@ -8,16 +8,18 @@ class ColumnCleaner:
         self.__output_queues = output_queues
 
     def callback(self, channel, method, properties, body):
-        if body.startswith(b'00'):
-            pass
+        flight = json.loads(body)
+        op_code = flight.get("op_code")
+        if op_code == 0:
             # EOF
-        filtered_byte_array = bytearray()
-        filtered_byte_array += body[:1]
-        body = body[3:].decode('utf-8')
-        body_dict = json.loads(body)
+            print("EOF !!!")
+            for queue in self.__output_queues:
+                publish_on(channel, queue, body)
+                acknowledge(channel, method)
+            return
         filtered_columns = dict()
         for column in self.__columns_names:
-            filtered_columns[column] = body_dict[column]
+            filtered_columns[column] = flight[column]
         message = json.dumps(filtered_columns)
         for queue in self.__output_queues:
             publish_on(channel, queue, message)

--- a/initial_column_cleaner/initial_column_cleaner.py
+++ b/initial_column_cleaner/initial_column_cleaner.py
@@ -12,7 +12,6 @@ class ColumnCleaner:
         op_code = flight.get("op_code")
         if op_code == 0:
             # EOF
-            print("EOF !!!")
             for queue in self.__output_queues:
                 publish_on(channel, queue, body)
                 acknowledge(channel, method)

--- a/initial_column_cleaner/main.py
+++ b/initial_column_cleaner/main.py
@@ -32,7 +32,6 @@ def main():
     config_params = initialize_config()
     input_queue = config_params["input_queue"]
     output_queues = config_params["output_queues"]
-    logging_level = config_params["logging_level"]
     columns_names = config_params["columns_names"]
     cleaner = ColumnCleaner(columns_names, output_queues)
     connection = connect_mom()

--- a/query_handler/main.py
+++ b/query_handler/main.py
@@ -3,10 +3,12 @@ import json
 
 
 def callback(channel, method, properties, body):
-    if body.startswith(b'00'):
-        pass
-        # EOF
     result = json.loads(body)
+    if result.get("op_code") == 0:
+        # EOF
+        print("Received EOF")
+        acknowledge(channel, method)
+        return
     print("Got result for query " + str(result["queryNumber"]))
     result.pop('queryNumber', None)
     print(result)

--- a/query_handler/main.py
+++ b/query_handler/main.py
@@ -6,7 +6,6 @@ def callback(channel, method, properties, body):
     result = json.loads(body)
     if result.get("op_code") == 0:
         # EOF
-        print("Received EOF")
         acknowledge(channel, method)
         return
     print("Got result for query " + str(result["queryNumber"]))

--- a/util/protocol.py
+++ b/util/protocol.py
@@ -1,29 +1,40 @@
-import struct
+import json
 
 OP_CODE_FLIGHT_REGISTER = 1
 OP_CODE_EOF = 0
 
 
 def encode_flight_register(flight):
-    opcode_bytes = OP_CODE_FLIGHT_REGISTER.to_bytes(1, byteorder="big")
+    flight["op_code"] = OP_CODE_FLIGHT_REGISTER
+    flight = json.dumps(flight)
     flight_bytes = flight.encode('utf-8')
     flight_length_bytes = len(flight_bytes).to_bytes(2, byteorder="big")
 
-    message = opcode_bytes + flight_length_bytes + flight_bytes
+    message = flight_length_bytes + flight_bytes
     return message
 
 
-def encode_flight_register_q(flight):
-    opcode_bytes = OP_CODE_FLIGHT_REGISTER.to_bytes(1, byteorder="big")
-    flight_length_bytes = len(flight).to_bytes(2, byteorder="big")
+def get_opcode(payload):
+    flight_str = payload.decode('utf-8')
+    flight = json.loads(flight_str)
+    return flight.get("op_code")
 
-    message = opcode_bytes + flight_length_bytes + flight
-    return message
+
+def decode_to_str(payload):
+    flight_str = payload.decode('utf-8')
+    return flight_str
 
 
 def encode_eof():
-    opcode_bytes = OP_CODE_EOF.to_bytes(1, byteorder="big")
-    payload_length = struct.pack('!H', 0)
+    eof = {"op_code": 0}
+    return json.dumps(eof)
 
-    eof_message = opcode_bytes + payload_length
-    return eof_message
+
+def encode_eof_b():
+    eof = {"op_code": 0}
+    eof = json.dumps(eof)
+    eof_bytes = eof.encode('utf-8')
+    eof_length_bytes = len(eof_bytes).to_bytes(2, byteorder="big")
+
+    message = eof_length_bytes + eof_bytes
+    return message


### PR DESCRIPTION
En las colas, ahora se escriben directamente objetos JSON con un campo `op_code`, y se omite la longitud. Además, los nodos también propagan los EOFs y terminan si los reciben.